### PR TITLE
Update testnet binary list with v18 binary

### DIFF
--- a/athens3/binary_list.json
+++ b/athens3/binary_list.json
@@ -91,7 +91,6 @@
     {
       "download_url": "https://github.com/zeta-chain/node/releases/download/v17.0.0/zetacored-linux-amd64",
       "binary_location": "cosmovisor/upgrades/v17-athens/bin/zetacored"
-    }
     },
     {
       "download_url": "https://github.com/zeta-chain/node/releases/download/v18.0.0/zetacored-linux-amd64",

--- a/athens3/binary_list.json
+++ b/athens3/binary_list.json
@@ -92,5 +92,10 @@
       "download_url": "https://github.com/zeta-chain/node/releases/download/v17.0.0/zetacored-linux-amd64",
       "binary_location": "cosmovisor/upgrades/v17-athens/bin/zetacored"
     }
+    },
+    {
+      "download_url": "https://github.com/zeta-chain/node/releases/download/v18.0.0/zetacored-linux-amd64",
+      "binary_location": "cosmovisor/upgrades/v18/bin/zetacored"
+    }
   ]
 }

--- a/mainnet/binary_list.json
+++ b/mainnet/binary_list.json
@@ -35,6 +35,10 @@
     {
       "download_url": "https://github.com/zeta-chain/node/releases/download/v17.0.0/zetacored-linux-amd64",
       "binary_location": "cosmovisor/upgrades/v17/bin/zetacored"
+    },
+    {
+      "download_url": "https://github.com/zeta-chain/node/releases/download/v18.0.0/zetacored-linux-amd64",
+      "binary_location": "cosmovisor/upgrades/v18/bin/zetacored"
     }
   ]
 }


### PR DESCRIPTION
TESTNET - ACTION REQUIRED (Planned upgrade of zetacored)

A new Proposal has been submitted for v18

GOVERNANCE PROPOSAL: TESTNET
PROPOSAL_ID: 71
LINK TO PROPOSAL: https://testnet.zetachain.explorers.guru/proposal/71

----------------UPGRADE_DESCRIPTION----------------
VOTING START TIME: "2024-07-15 14:49:04 UTC"
VOTING END TIME: "2024-07-16 14:49:04 UTC"
UPGRADE DATETIME (expected): "2024-07-17 15:30 UTC / 08:30 PDT"
UPGRADE HEIGHT: 5906950

Make sure to upgrade your binaries at the estimated upgrade time.

Please note that the upgrade is named v18. Cosmovisor will expect the binaries under ./cosmovisor/upgrades/v18/


Thanks for your support, ZetaChain Team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for downloading and installing version 18.0.0 of the `zetacored` binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->