### PR TITLE
Add v19 binary to Testnet binary_list.json

### DIFF
--- a/athens3/binary_list.json
+++ b/athens3/binary_list.json
@@ -95,6 +95,10 @@
     {
       "download_url": "https://github.com/zeta-chain/node/releases/download/v18.0.0/zetacored-linux-amd64",
       "binary_location": "cosmovisor/upgrades/v18/bin/zetacored"
+    },
+    {
+      "download_url": "https://github.com/zeta-chain/node/releases/download/v19.0.0/zetacored-linux-amd64",
+      "binary_location": "cosmovisor/upgrades/v19/bin/zetacored"
     }
   ]
 }


### PR DESCRIPTION
Adding v19 binary to Testnet binary list json file 

**GOVERNANCE PROPOSAL:** ATHENS TESTNET
**PROPOSAL_ID:** 75
**LINK TO PROPOSAL:** https://testnet.zetachain.explorers.guru/proposal/75


----------------UPGRADE_DESCRIPTION----------------
**VOTING START TIME:** "Aug 07, 2024 1:57 PM UTC"
**VOTING END TIME:** "Aug 08, 2024 1:57 PM UTC"
**UPGRADE DATETIME (expected):** "2024-08-14 14:45 UTC / 07:45 PDT"
**UPGRADE HEIGHT:** 6325420

Please vote YES, and prepare for the version upgrade at block **6325420**.
VOTING PERIOD: 24.00hrs Make sure to upgrade your binaries at the estimated upgrade time.

**Please note that the upgrade is named v19. Cosmovisor will expect the binaries under cosmovisor/upgrades/v19/**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new downloadable binary for version 19.0.0 of the software, providing direct access via a new download URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->