### PR TITLE
V19 app toml app db backend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*     @zeta-chain/DevOps

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+# Description
+
+<!--- Include a summary of the changes and any related issues. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
+
+# Is this deployed somewhere outside of the CI/CD process already, and if so, where?
+
+- [ ] Developnet
+- [ ] Athens-Validators
+- [ ] Mainnet-Validators
+
+# How Has This Been Tested?
+
+<!--- Describe the tests that you ran to verify your changes. -->
+
+# Checklist:
+
+- [ ] I have performed a self-review of my code
+- [ ] My changes generate no new warnings
+
+[comment]: <## Env variables>
+
+[comment]: <## Screenshots>

--- a/athens3/app.toml
+++ b/athens3/app.toml
@@ -10,6 +10,7 @@ inter-block-cache = true
 index-events = []
 iavl-cache-size = 781250
 iavl-disable-fastnode = true
+app-db-backend = "pebbledb"
 
 [telemetry]
 service-name = "tss"

--- a/devnet/app.toml
+++ b/devnet/app.toml
@@ -68,6 +68,12 @@ iavl-cache-size = 781250
 # Default is true.
 iavl-disable-fastnode = true
 
+# AppDBBackend defines the database backend type to use for the application and snapshots DBs.
+# An empty string indicates that a fallback will be used.
+# The fallback is the db_backend value set in Tendermint's config.toml.
+# The default value is ""
+app-db-backend = "pebbledb"
+
 ###############################################################################
 ###                         Telemetry Configuration                         ###
 ###############################################################################

--- a/mainnet/app.toml
+++ b/mainnet/app.toml
@@ -10,6 +10,7 @@ inter-block-cache = true
 index-events = []
 iavl-cache-size = 781250
 iavl-disable-fastnode = true
+app-db-backend = "pebbledb"
 
 [telemetry]
 service-name = "tss"


### PR DESCRIPTION
Changes: 
- Add CODEOWNERS (devops)
- Add PR template
- Update app.toml to explicitly set:
```
app-db-backend = "pebbledb"
```

This is due to the partial [Athens v19 upgrade failure](https://status.zetachain.com/incidents/wmq1z4v42hwk).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option for the database backend, allowing users to select `"pebbledb"` for enhanced data management capabilities across different environments (Athens, Devnet, Mainnet). 

- **Chores**
  - Updated configuration files to include the new `app-db-backend` parameter without altering existing functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->