### PR TITLE
Mainnet v19 upgrade binary

### DIFF
--- a/mainnet/binary_list.json
+++ b/mainnet/binary_list.json
@@ -39,6 +39,10 @@
     {
       "download_url": "https://github.com/zeta-chain/node/releases/download/v18.0.0/zetacored-linux-amd64",
       "binary_location": "cosmovisor/upgrades/v18/bin/zetacored"
+    },
+    {
+      "download_url": "https://github.com/zeta-chain/node/releases/download/v19.1.1/zetacored-linux-amd64",
+      "binary_location": "cosmovisor/upgrades/v19/bin/zetacored"
     }
   ]
 }


### PR DESCRIPTION
Add v19 binary for Mainnet upgrade.

**PROPOSAL_ID:** 33

**LINK(s) TO PROPOSAL:**
- https://hub.zetachain.com/governance/proposal/33
- https://www.mintscan.io/zeta/proposals/33

**UPGRADE DATETIME (expected):** "2024-09-04 14:45 UTC / 07:45 PDT"

**UPGRADE HEIGHT:** 4696150

**Please note:**
- The upgrade is named v19. Cosmovisor will expect the binaries under `.zetacored/cosmovisor/upgrades/v19/` 

- Due to an issue uncovered during the Athens v19 upgrade, unless you previously had a value set for `app-db-backend` in `app.toml` in addition to the value set for `db_backend` in `config.toml` , then you must define `app-db-backend` in `app.toml` above the telemetry section, and it must be set to `pebbledb` 

- - More succinctly: If no value was set, `app.toml` must set `app-db-backend = "pebbledb"` above the telemetry section in order for your node to safely complete the upgrade. 
- - The above is true especially if you set `db_backend` to something other than `pebbledb` in `config.toml` as that triggers the failed upgrade case unless `app.toml` to contains the line: `app-db-backend = "pebbledb"`
