### PR TITLE
update binaries for mainnet and athens3

### DIFF
--- a/athens3/binary_list.json
+++ b/athens3/binary_list.json
@@ -99,6 +99,10 @@
     {
       "download_url": "https://github.com/zeta-chain/node/releases/download/v19.0.0/zetacored-linux-amd64",
       "binary_location": "cosmovisor/upgrades/v19/bin/zetacored"
+    },
+    {
+      "download_url": "https://github.com/zeta-chain/node/releases/download/v20.0.1/zetacored-linux-amd64",
+      "binary_location": "cosmovisor/upgrades/v20/bin/zetacored"
     }
   ]
 }

--- a/athens3/binary_list.json
+++ b/athens3/binary_list.json
@@ -101,7 +101,7 @@
       "binary_location": "cosmovisor/upgrades/v19/bin/zetacored"
     },
     {
-      "download_url": "https://github.com/zeta-chain/node/releases/download/v20.0.1/zetacored-linux-amd64",
+      "download_url": "https://github.com/zeta-chain/node/releases/download/v20.0.2/zetacored-linux-amd64",
       "binary_location": "cosmovisor/upgrades/v20/bin/zetacored"
     }
   ]

--- a/mainnet/binary_list.json
+++ b/mainnet/binary_list.json
@@ -41,7 +41,7 @@
       "binary_location": "cosmovisor/upgrades/v18/bin/zetacored"
     },
     {
-      "download_url": "https://github.com/zeta-chain/node/releases/download/v19.1.1/zetacored-linux-amd64",
+      "download_url": "https://github.com/zeta-chain/node/releases/download/v19.1.7/zetacored-linux-amd64",
       "binary_location": "cosmovisor/upgrades/v19/bin/zetacored"
     }
   ]


### PR DESCRIPTION
# Description

- Update mainnet v19 binary to v19.1.7
- Update athens3 to have v20 binary(v20.0.2)

# Is this deployed somewhere outside of the CI/CD process already, and if so, where?

- [ ] Developnet
- [ ] Athens-Validators
- [ ] Mainnet-Validators

# How Has This Been Tested?

<!--- Describe the tests that you ran to verify your changes. -->

# Checklist:

- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings

[comment]: <## Env variables>

[comment]: <## Screenshots>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new binary version (20.0.1) for the ZetaChain node, enhancing user access to the latest software.
  
- **Updates**
	- Updated the download URL for version 19 of the Zeta Core software to the latest version (19.1.7), ensuring users have access to the most recent improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->