### PR TITLE
add v20.0.2 binary for mainnet

### DIFF
--- a/mainnet/binary_list.json
+++ b/mainnet/binary_list.json
@@ -43,6 +43,10 @@
     {
       "download_url": "https://github.com/zeta-chain/node/releases/download/v19.1.7/zetacored-linux-amd64",
       "binary_location": "cosmovisor/upgrades/v19/bin/zetacored"
+    },
+    {
+      "download_url": "https://github.com/zeta-chain/node/releases/download/v20.0.2/zetacored-linux-amd64",
+      "binary_location": "cosmovisor/upgrades/v20/bin/zetacored"
     }
   ]
 }


### PR DESCRIPTION
# Description

- add v20.0.2 binary for mainnet

# Is this deployed somewhere outside of the CI/CD process already, and if so, where?

- [ ] Developnet
- [ ] Athens-Validators
- [ ] Mainnet-Validators

# How Has This Been Tested?

<!--- Describe the tests that you ran to verify your changes. -->

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings

[comment]: <## Env variables>

[comment]: <## Screenshots>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for version 20.0.2 of the `zetacored` binary for Linux AMD64.
	- Updated the binary list to include a new download URL and binary location for the latest software version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->