### PR TITLE
Update `iavl-disable-fastnode` default value

### DIFF
--- a/athens3/app.toml
+++ b/athens3/app.toml
@@ -9,7 +9,7 @@ min-retain-blocks = 0
 inter-block-cache = true
 index-events = []
 iavl-cache-size = 781250
-iavl-disable-fastnode = true
+iavl-disable-fastnode = false
 app-db-backend = "pebbledb"
 
 [telemetry]

--- a/devnet/app.toml
+++ b/devnet/app.toml
@@ -65,8 +65,8 @@ index-events = []
 iavl-cache-size = 781250
 
 # IAVLDisableFastNode enables or disables the fast node feature of IAVL. 
-# Default is true.
-iavl-disable-fastnode = true
+# Default is false.
+iavl-disable-fastnode = false
 
 # AppDBBackend defines the database backend type to use for the application and snapshots DBs.
 # An empty string indicates that a fallback will be used.

--- a/mainnet/app.toml
+++ b/mainnet/app.toml
@@ -9,7 +9,7 @@ min-retain-blocks = 0
 inter-block-cache = true
 index-events = []
 iavl-cache-size = 781250
-iavl-disable-fastnode = true
+iavl-disable-fastnode = false
 app-db-backend = "pebbledb"
 
 [telemetry]


### PR DESCRIPTION
The default generated by `zetacored init` is false.

`false` is the best default option. `true` should only really be set before cosmos-sdk upgrades when iavl migrations are needed but the validator wishes to defer them. This option should always be `false` on snapshotters.

Related to https://github.com/zeta-chain/node/issues/3150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Updated the `iavl-disable-fastnode` setting from `true` to `false` across all environments (Athens, Devnet, Mainnet), potentially impacting performance and resource utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->