### PR TITLE
remove btc testnet3 config

### DIFF
--- a/athens3/zetaclient_config_example.json
+++ b/athens3/zetaclient_config_example.json
@@ -80,14 +80,6 @@
         }
     },
     "BTCChainConfigs": {
-        "18332": {
-            "ballot_threshold": "0",
-            "min_observer_delegation": "0",
-            "RPCUsername": "BTC_USER",
-            "RPCPassword": "BTC_PASS",
-            "RPCHost": "BTC_TESTNET3_RPC_ENDPOINT",
-            "RPCParams": "testnet3"
-        },
         "18333": {
             "ballot_threshold": "0",
             "min_observer_delegation": "0",


### PR DESCRIPTION
# Description

- remove btc testnet3 config as chain is no longer supported

# Is this deployed somewhere outside of the CI/CD process already, and if so, where?

- [ ] Developnet
- [ ] Athens-Validators
- [ ] Mainnet-Validators

# How Has This Been Tested?

<!--- Describe the tests that you ran to verify your changes. -->

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings

[comment]: <## Env variables>

[comment]: <## Screenshots>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed outdated configuration block for the Bitcoin chain on port `18332`.
  
- **Chores**
	- Maintained the overall structure of the configuration file, ensuring other sections remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->