### PR TITLE
update pyth price pusher config

### DIFF
--- a/mainnet/pyth-price-pusher-config.yaml
+++ b/mainnet/pyth-price-pusher-config.yaml
@@ -1,44 +1,44 @@
 ---
 - alias: BTC/USD
   id: "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43"
-  time_difference: 30
-  price_deviation: 5
-  confidence_ratio: 1
+  time_difference: 60
+  price_deviation: 0.5
+  confidence_ratio: 100
 - alias: BNB/USD
   id: "0x2f95862b045670cd22bee3114c39763a4a08beeb663b145d283c31d7d1101c4f"
-  time_difference: 30
-  price_deviation: 1
-  confidence_ratio: 1
+  time_difference: 60
+  price_deviation: 0.5
+  confidence_ratio: 100
 - alias: ETH/USD
   id: "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
-  time_difference: 30
-  price_deviation: 1
-  confidence_ratio: 1
+  time_difference: 60
+  price_deviation: 0.5
+  confidence_ratio: 100
 - alias: USDC/USD
   id: "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a"
-  time_difference: 30
-  price_deviation: 1
-  confidence_ratio: 1
+  time_difference: 60
+  price_deviation: 0.5
+  confidence_ratio: 100
   early_update:
-    time_difference: 30
+    time_difference: 60
     price_deviation: 0.5
-    confidence_ratio: 0.1
+    confidence_ratio: 100
 - alias: ZETA/USD
   id: "0xb70656181007f487e392bf0d92e55358e9f0da5da6531c7c4ce7828aa11277fe"
-  time_difference: 30
-  price_deviation: 1
-  confidence_ratio: 1
+  time_difference: 60
+  price_deviation: 0.5
+  confidence_ratio: 100
 - alias: USDT/USD
   id: "0x2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b"
-  time_difference: 30
-  price_deviation: 1
-  confidence_ratio: 1
+  time_difference: 60
+  price_deviation: 0.5
+  confidence_ratio: 100
   early_update:
-    time_difference: 30
+    time_difference: 60
     price_deviation: 0.5
-    confidence_ratio: 0.1
+    confidence_ratio: 100
 - alias: POL/USD
   id: "0xffd11c5a1cfd42f80afb2df4d9f264c15f956d68153335374ec10722edd70472"
-  time_difference: 30
-  price_deviation: 1
-  confidence_ratio: 1
+  time_difference: 60
+  price_deviation: 0.5
+  confidence_ratio: 100


### PR DESCRIPTION
# Description

- update pyth price pusher config to push every 60 minutes OR when there is a .5% change in price. This should reduce the number of updates we need to push as based on https://github.com/zeta-chain/infrastructure/issues/2176

# Is this deployed somewhere outside of the CI/CD process already, and if so, where?

- [ ] Developnet
- [ ] Athens-Validators
- [ ] Mainnet-Validators

# How Has This Been Tested?

<!--- Describe the tests that you ran to verify your changes. -->

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings

[comment]: <## Env variables>

[comment]: <## Screenshots>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings for all price feeds to require a longer time interval between updates, a smaller allowed price deviation, and a much higher confidence ratio. These changes affect how and when price updates are triggered for all monitored assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->