### PR TITLE
add extra seed on athens network config

### DIFF
--- a/athens3/config.toml
+++ b/athens3/config.toml
@@ -49,7 +49,7 @@ laddr = "tcp://0.0.0.0:26656"
 # IMPORTANT! Replace the placeholder below with your actual external IP address
 external_address = "{YOUR_EXTERNAL_IP_ADDRESS_HERE}:26656"
 
-seeds = "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@testnet-seeds.polkachu.com:22556"
+seeds = "f445f264cd13470378c3d165e8edb8273836bd6a@zetachain-testnet-seed.itrocket.net:15656,ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@testnet-seeds.polkachu.com:22556"
 persistent_peers = ""
 addr_book_file = "config/addrbook.json"
 addr_book_strict = true


### PR DESCRIPTION
# Description

<!--- Include a summary of the changes and any related issues. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

# Is this deployed somewhere outside of the CI/CD process already, and if so, where?

- [ ] Developnet
- [ ] Athens-Validators
- [ ] Mainnet-Validators

# How Has This Been Tested?

<!--- Describe the tests that you ran to verify your changes. -->

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings

[comment]: <## Env variables>

[comment]: <## Screenshots>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single configuration change limited to P2P seed discovery; low risk aside from potential connectivity issues if the new seed is unreliable.
> 
> **Overview**
> Updates `athens3/config.toml` P2P settings to add an additional seed node (`zetachain-testnet-seed.itrocket.net:15656`) alongside the existing PolkaChu testnet seed, improving peer discovery bootstrapping for Athens nodes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7feafd9588caa347572312a2ab042844ff3574f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network node seed configuration to include an additional seed for improved network redundancy and connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->