### PR TITLE
chore: increase pyth price pusher thresholds to reduce costs

### DIFF
--- a/mainnet/pyth-price-pusher-config.yaml
+++ b/mainnet/pyth-price-pusher-config.yaml
@@ -1,44 +1,36 @@
 ---
 - alias: BTC/USD
   id: "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43"
-  time_difference: 300
+  time_difference: 600
   price_deviation: 1
   confidence_ratio: 100
 - alias: BNB/USD
   id: "0x2f95862b045670cd22bee3114c39763a4a08beeb663b145d283c31d7d1101c4f"
-  time_difference: 300
+  time_difference: 600
   price_deviation: 1
   confidence_ratio: 100
 - alias: ETH/USD
   id: "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
-  time_difference: 300
+  time_difference: 600
   price_deviation: 1
   confidence_ratio: 100
 - alias: USDC/USD
   id: "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a"
-  time_difference: 300
+  time_difference: 600
   price_deviation: 1
   confidence_ratio: 100
-  early_update:
-    time_difference: 300
-    price_deviation: 1
-    confidence_ratio: 100
 - alias: ZETA/USD
   id: "0xb70656181007f487e392bf0d92e55358e9f0da5da6531c7c4ce7828aa11277fe"
-  time_difference: 300
+  time_difference: 600
   price_deviation: 1
   confidence_ratio: 100
 - alias: USDT/USD
   id: "0x2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b"
-  time_difference: 300
+  time_difference: 600
   price_deviation: 1
   confidence_ratio: 100
-  early_update:
-    time_difference: 300
-    price_deviation: 1
-    confidence_ratio: 100
 - alias: POL/USD
   id: "0xffd11c5a1cfd42f80afb2df4d9f264c15f956d68153335374ec10722edd70472"
-  time_difference: 300
+  time_difference: 600
   price_deviation: 1
   confidence_ratio: 100

--- a/mainnet/pyth-price-pusher-config.yaml
+++ b/mainnet/pyth-price-pusher-config.yaml
@@ -1,44 +1,44 @@
 ---
 - alias: BTC/USD
   id: "0xe62df6c8b4a85fe1a67db44dc12de5db330f7ac66b72dc658afedf0f4a415b43"
-  time_difference: 60
-  price_deviation: 0.5
+  time_difference: 300
+  price_deviation: 1
   confidence_ratio: 100
 - alias: BNB/USD
   id: "0x2f95862b045670cd22bee3114c39763a4a08beeb663b145d283c31d7d1101c4f"
-  time_difference: 60
-  price_deviation: 0.5
+  time_difference: 300
+  price_deviation: 1
   confidence_ratio: 100
 - alias: ETH/USD
   id: "0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace"
-  time_difference: 60
-  price_deviation: 0.5
+  time_difference: 300
+  price_deviation: 1
   confidence_ratio: 100
 - alias: USDC/USD
   id: "0xeaa020c61cc479712813461ce153894a96a6c00b21ed0cfc2798d1f9a9e9c94a"
-  time_difference: 60
-  price_deviation: 0.5
+  time_difference: 300
+  price_deviation: 1
   confidence_ratio: 100
   early_update:
-    time_difference: 60
-    price_deviation: 0.5
+    time_difference: 300
+    price_deviation: 1
     confidence_ratio: 100
 - alias: ZETA/USD
   id: "0xb70656181007f487e392bf0d92e55358e9f0da5da6531c7c4ce7828aa11277fe"
-  time_difference: 60
-  price_deviation: 0.5
+  time_difference: 300
+  price_deviation: 1
   confidence_ratio: 100
 - alias: USDT/USD
   id: "0x2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b"
-  time_difference: 60
-  price_deviation: 0.5
+  time_difference: 300
+  price_deviation: 1
   confidence_ratio: 100
   early_update:
-    time_difference: 60
-    price_deviation: 0.5
+    time_difference: 300
+    price_deviation: 1
     confidence_ratio: 100
 - alias: POL/USD
   id: "0xffd11c5a1cfd42f80afb2df4d9f264c15f956d68153335374ec10722edd70472"
-  time_difference: 60
-  price_deviation: 0.5
+  time_difference: 300
+  price_deviation: 1
   confidence_ratio: 100


### PR DESCRIPTION
## Summary
- Increase `time_difference` from 60s to 300s (5 min) for all feeds
- Increase `price_deviation` from 0.5% to 1% for all feeds
- Update `early_update` thresholds on USDC/USDT to match

## Context
Each Pyth price pusher update costs ~0.6 ZETA in on-chain update fees (msg.value to the Pyth contract). With `time_difference: 60`, updates fire at minimum every 60 seconds, costing ~864 ZETA/day. These changes reduce update frequency by ~5x, bringing estimated cost to ~170 ZETA/day or less.

## Related
- argo-cd-apps PR for image upgrade: upgrading to v10.3.1

## Test plan
- [ ] Verify price pusher picks up new config after deployment
- [ ] Monitor update frequency drops to ~every 5 min
- [ ] Confirm on-chain prices remain fresh enough for downstream consumers

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config-only change, but it reduces oracle update cadence and tolerates larger price moves, which could impact downstream consumers if they rely on fresher prices.
> 
> **Overview**
> In `mainnet/pyth-price-pusher-config.yaml`, increases `time_difference` from 60s to 300s and `price_deviation` from 0.5 to 1 for all configured price feeds.
> 
> Updates `early_update` thresholds for `USDC/USD` and `USDT/USD` to match the new 300s/1 settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa0c89562c70bcb690ca76b6c9dcd2cff753d9d0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration for price-feed monitoring across multiple assets (BTC, BNB, ETH, USDC, ZETA, USDT, POL): increased update interval and relaxed deviation threshold to reduce spurious updates.
  * Simplified USDC and USDT settings by removing per-asset early-update overrides for more consistent global behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->