### PR TITLE
testnet: update peers

### DIFF
--- a/athens3/config.toml
+++ b/athens3/config.toml
@@ -50,7 +50,7 @@ laddr = "tcp://0.0.0.0:26656"
 external_address = "{YOUR_EXTERNAL_IP_ADDRESS_HERE}:26656"
 
 seeds = "f445f264cd13470378c3d165e8edb8273836bd6a@zetachain-testnet-seed.itrocket.net:15656,ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0@testnet-seeds.polkachu.com:22556"
-persistent_peers = ""
+persistent_peers = "d21b103628b0d5d824bbe81b809d8dc457bd2059@zetachain-testnet-peer.itrocket.net:16656,4d2a5330c949d1750f5296c7967d2e79c841b3ba@185.17.173.102:31011,a918d08544b5f4e0a9eb20bf91f343eb71b6d5ee@164.90.181.99:26656,e72dff87c241771f329beb8b31ed3f45d2fbda09@65.108.202.244:22556,6b372a420dead6d23bd0dff194c9456cddbbfca0@23.88.75.148:31460,fdc0a43704510897ad55a611e3f0d6f2c888c40e@95.217.200.98:22556"
 addr_book_file = "config/addrbook.json"
 addr_book_strict = true
 max_num_inbound_peers = 40


### PR DESCRIPTION
# Description

<!--- Include a summary of the changes and any related issues. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

# Is this deployed somewhere outside of the CI/CD process already, and if so, where?

- [ ] Developnet
- [ ] Athens-Validators
- [ ] Mainnet-Validators

# How Has This Been Tested?

<!--- Describe the tests that you ran to verify your changes. -->

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings

[comment]: <## Env variables>

[comment]: <## Screenshots>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but incorrect or stale peer addresses could impact node connectivity on the testnet.
> 
> **Overview**
> Updates `athens3/config.toml` to set `persistent_peers` to a populated list of testnet peers (instead of empty), improving default P2P connectivity while leaving seeds unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77810231c4c947bec151a5da3499daa100f1dc49. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated persistent peer connectivity configuration to enhance node network stability and peer discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->