### PR TITLE
chore(mainnet): add recovery snapshot pointer for the wedged mainnet nodes

### DIFF
--- a/mainnet/recovery/polkachu-18384852.json
+++ b/mainnet/recovery/polkachu-18384852.json
@@ -1,0 +1,15 @@
+{
+  "snapshots": [
+    {
+      "networkVersion": "v36",
+      "height": "18384852",
+      "creationDate": "2026-08-27T08:09:00Z",
+      "filename": "zetachain_18384852.tar.lz4",
+      "size": 32071371040,
+      "link": "https://snapshots.polkachu.com/snapshots/zetachain/zetachain_18384852.tar.lz4",
+      "checksums": {
+        "md5": "e4b8039efd528dff9b2e945a0689ac1b"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Adds `mainnet/recovery/polkachu-18384852.json` — snapshot metadata used to rebuild the ZetaChain-operated mainnet fullnodes and snapshotter, which currently cannot bootstrap from our own snapshot service.

Consumed via `ZETACHAIN_SNAPSHOT_METADATA_URL` by the pods in zeta-chain/argo-cd-apps#1967. **Not** the default bootstrap path — nothing changes for anyone using `snapshots.rpc.zetachain.com`.

## Expected Result

Pods pointed at this file restore from a snapshot taken by a node in consensus with the chain, and sync to head.

## How it was vetted

Checked rather than assumed, because two of these would have failed silently:

| | |
| --- | --- |
| height | 18384852 |
| db backend | **pebbledb** — matches our `db_backend`/`app-db-backend`. Confirmed by streaming 2.4 GB of the archive and finding `data/evidence.db/OPTIONS-*`; goleveldb writes `.ldb` and no `OPTIONS-*`. The listing page does not state this. |
| compression | lz4 — `restore_snapshot` in zetacored-docker only special-cases lz4 |
| md5 | `e4b8039efd528dff9b2e945a0689ac1b` |

The provider publishes no checksum file and their ETag is a multipart tag (`…-3824`), so it is not the file md5 and can't be read from headers. `dl-pipe -hash` needs one, so the full 32 GB was streamed in-cluster (~31 min); etag, content-length and last-modified were re-checked afterwards to confirm the file hadn't rotated mid-download.

## Temporary

The upstream snapshot is deleted daily, so **this link will rot**. Remove this file once our own snapshotter is publishing clean snapshots again, along with `snapshotMetadataUrl` in both mainnet overlays in argo-cd-apps.

Note the source node is validator-shaped (`indexer = "null"`, `pruning-keep-recent = "100"`), so tx history and state below 18384852 will be absent until nodes are rebuilt from our own indexed snapshot.

## Merge order

Must land **before** zeta-chain/argo-cd-apps#1967, which references this file by raw URL — otherwise init fails on a 404 metadata fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
